### PR TITLE
Do not replace existing auth headers

### DIFF
--- a/src/framed/d2lfetch-auth-framed.js
+++ b/src/framed/d2lfetch-auth-framed.js
@@ -9,6 +9,10 @@ export class D2LFetchAuthFramed {
 
 		next = next || function(r) { return Promise.resolve(r); };
 
+		if (request.headers.get('Authorization')) {
+			return next(request);
+		}
+
 		return this._getToken('*:*:*')
 			.then(function(token) {
 				const headers = { 'Authorization': `Bearer ${token}` };

--- a/src/unframed/d2lfetch-auth.js
+++ b/src/unframed/d2lfetch-auth.js
@@ -14,6 +14,10 @@ export class D2LFetchAuth {
 
 		next = next || function(r) { return Promise.resolve(r); };
 
+		if (request.headers.get('Authorization')) {
+			return next(request);
+		}
+
 		if (this._isRelativeUrl(request.url)) {
 			request = new Request(request, {
 				credentials: 'same-origin'

--- a/test/d2l-fetch-auth/d2l-fetch-auth-framed.js
+++ b/test/d2l-fetch-auth/d2l-fetch-auth-framed.js
@@ -37,6 +37,15 @@ describe('d2l-fetch-auth', function() {
 					.then((function() { expect.fail(); }), function(err) { expect(err instanceof TypeError).to.equal(true); });
 			});
 		});
+
+		it('should not replace an existing authorization header', function() {
+			var token = 'this is a custom token from this do not replace auth header test';
+			var request = new Request('path/to/data', { headers: { authorization: token } });
+			return window.d2lfetch.auth(request)
+				.then(function(output) {
+					expect(output.headers.get('Authorization')).to.equal(token);
+				});
+		});
 	});
 
 });

--- a/test/d2l-fetch-auth/d2l-fetch-auth.js
+++ b/test/d2l-fetch-auth/d2l-fetch-auth.js
@@ -79,6 +79,15 @@ describe('d2l-fetch-auth', function() {
 			});
 		});
 
+		it('should not replace an existing authorization header', function() {
+			var token = 'this is a custom token from this do not replace auth header test';
+			var request = new Request('path/to/data', { headers: { authorization: token } });
+			return window.d2lfetch.auth(request)
+				.then(function(output) {
+					expect(output.headers.get('Authorization')).to.equal(token);
+				});
+		});
+
 		it('should call the next function if provided', function() {
 			var next = sandbox.stub().returns(Promise.resolve());
 			return window.d2lfetch.auth(getRequest('/path/to/data'), next)


### PR DESCRIPTION
If the request being supplied has already been given auth headers then this middleware should just pass it along to the rest of the chain. This can allow for users of `d2lfetch` to make `fetch` calls using tokens they have acquired themselves rather than being forced to use the ones this middleware would otherwise apply.