### PR TITLE
Make bower-able

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ script:
 - npm run build
 - npm run test:lint
 - wct --skip-plugin local
-- 'if [ "$TRAVIS_BRANCH" == "master" ]; then frauci-update-version && export TRAVIS_TAG=$(frauci-get-version) && npm run build && npm run publish-release; fi'
+- ./update.sh
 env:
   global:
-  - REPO_NAME=d2l-fetch-auth
   # SAUCE_USERNAME
   - secure: PAi0SiC2fng8OzZGqy6g5zlUhjgYcCGIvwxi0EBFjnZXqznQ2uvBqQia5egbWxMAW7nt7APNJQByHcB/Ygtg2AB7kBxTu8nas9qDrwxD1/31liga+cSKbneigV8GQtacMGEa4Lr3jsABF0kzX4PaRCwbzmOkZAVjkrK6ay/XaMSXhgkCkW6T4MYcZ59PgdSaoNemPf6aRRnGE+KpK5Y3Ee+UkcTAqjxwF+xfF3dC63bu42hteRFFL9G4jvXcP6vmqFosbfMYIfNeFXV9KIDM4hnmpyui7pqleiqHJWEF3ivhqSTfrwAsOUKWqtMNeQB4FWvH3SQTzYV6cdmLXWhG/6f0u2jj+ET2wkgHyojRQjMB6uTGG8jKWesScJuudoF+Vgc84NKiQ69aI58p1zEjPgRWoaMNOXDWO2vdBBTTOXgdXoc3BHTAVnpzNNina90k7NqplBxMSn8kkqExrm3nWnm5RZjHlVhHTI8laeIynkUdEMBpE7AHwcMwM+AKSQ1g2nAe0ZiZrqzrrujwxr1JYfZcVc7yrX0FiGIoVVE4fFelgk+a3dsQpytlK9NUWrtlnwwv8J/GUCCwql+MZE/AKZfd1mXof/m0TVdKsdPaaDeKSrp44W2Z49tTulbUgBfCZZMXuK++C+odKlMPYccAJoKyOQ2NfXshTICJB/EVF3w=
   # CDN_SECRET

--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ Alternatively, if you are making requests from within the context of an iFramed 
 <script src="../dist/d2lfetch-auth-framed.js"></script>
 ```
 
-This will add the `auth` middleware function to the `d2lfetch` object.
+This will add the `auth` middleware function to the `d2lfetch` object. Alternatively, you can install `d2l-fetch-auth` via bower:
+
+```sh
+bower install Brightspace/d2l-fetch-auth
+```
+
+and reference it as you would any other bower package:
+
+```html
+<link rel="import" href="../d2l-fetch-auth/d2l-fetch-auth.html">
+<link rel="import" href="../d2l-fetch-auth/d2l-fetch-auth-framed.html">
+```
 
 ### Auth
 

--- a/d2l-fetch-auth-framed.html
+++ b/d2l-fetch-auth-framed.html
@@ -1,0 +1,2 @@
+<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-auth IS RELEASED -->
+<script src="https://s.brightspace.com/lib/d2lfetch-auth/0.6.0/d2lfetch-auth-framed.js"></script>

--- a/d2l-fetch-auth.html
+++ b/d2l-fetch-auth.html
@@ -1,0 +1,2 @@
+<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-auth IS RELEASED -->
+<script src="https://s.brightspace.com/lib/d2lfetch-auth/0.6.0/d2lfetch-auth.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "d2l-fetch-auth",
-  "version": "0.6.0",
   "description": "Provides a middleware function for wrapping a window.Request object with d2l authentication for use with d2l-fetch",
   "main": "index.js",
   "author": "D2L Corporation",
@@ -38,7 +37,6 @@
     "eslint": "^3.19.0",
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^2.0.1",
-    "frau-ci": "^1.33.0",
     "frau-publisher": "^2.6.2",
     "peanut-gallery": "^1.2.0",
     "web-component-tester": "^6.0.0",

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+if ! [ "$TRAVIS_BRANCH" == "master" ] || ! [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+	echo "Version is only bumped on master"
+	exit 0
+fi
+
+lastVersion=$(git describe --abbrev=0)
+versionRegex='^([0-9]+)\.([0-9]+)\.([0-9]+)$'
+if ! [[ $lastVersion =~ $versionRegex ]]; then
+	echo $lastVersion "is not a valid semver string"
+	exit 1
+fi
+
+majorVersion=${BASH_REMATCH[1]}
+minorVersion=${BASH_REMATCH[2]}
+patchVersion=${BASH_REMATCH[3]}
+
+lastLogMessage=$(git log -1 --pretty=format:%s%b)
+lastLogMessageShort=$(git log -1 --pretty=format:%s)
+
+majorRegex='\[increment major\]'
+patchRegex='\[increment patch\]'
+if [[ $lastLogMessage =~ $majorRegex ]]; then
+	majorVersion=$((majorVersion + 1))
+elif [[ $lastLogMessage =~ $patchRegex ]]; then
+	patchVersion=$((patchVersion + 1))
+else
+	minorVersion=$((minorVersion + 1))
+fi
+
+newVersion="${majorVersion}.${minorVersion}.${patchVersion}"
+
+# Add the upstream using GITHUB_RELEASE_TOKEN
+git remote add upstream "https://${GITHUB_RELEASE_TOKEN}@github.com/Brightspace/d2l-fetch-auth.git"
+
+# Pull the merge commit
+git pull upstream master
+git checkout upstream/master
+
+# Set config so this commit shows up as coming from Travis
+git config --global user.email "travis@travis-ci.com"
+git config --global user.name "Travis CI"
+
+echo "Updating from ${lastVersion} to ${newVersion}"
+echo "<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-auth IS RELEASED -->" > d2l-fetch-auth.html
+echo "<script src=\"https://s.brightspace.com/lib/d2lfetch-auth/"$newVersion"/d2lfetch-auth.js\"></script>" >> d2l-fetch-auth.html
+echo "<!-- CHANGES TO THIS FILE WILL BE LOST - IT IS AUTOMATICALLY GENERATED WHEN d2l-fetch-auth IS RELEASED -->" > d2l-fetch-auth-framed.html
+echo "<script src=\"https://s.brightspace.com/lib/d2lfetch-auth/"$newVersion"/d2lfetch-auth-framed.js\"></script>" >> d2l-fetch-auth-framed.html
+
+# Add the updated d2l-fetch-auth.html, and add a new tag to create the release
+git add .
+git commit -m "[skip ci] Update to ${newVersion}"
+git tag -a ${newVersion} -m "${newVersion} - ${lastLogMessageShort}"
+
+git status
+
+git push upstream HEAD:master --tags
+
+# Publish the release via frau-publisher
+export TRAVIS_TAG=$newVersion
+npm run publish-release


### PR DESCRIPTION
Adding these files allows us to use bower to control the versioning of this package, rather than using the CDNified versions and hoping that they won't conflict. These files are automatically updated by Travis to point at the CDN-ified scripts that will be generated by frau-ci in the next step. Since the new version isn't released until _after_ this commit is pushed, it does theoretically mean that if somebody pulled master at just the right moment, d2l-fetch-auth.html and d2l-fetch-auth-framed.html would be pointing to non-existant files, but oh well. (If the consumer is using a proper bower version, this situation can't occur since the new version is only generated after the new files are CDN-ified.)