### PR TITLE
optionally caching the auth token in local storage

### DIFF
--- a/src/unframed/index.js
+++ b/src/unframed/index.js
@@ -2,6 +2,12 @@ import { D2LFetchAuth } from './d2lfetch-auth.js';
 
 const fetchAuth = new D2LFetchAuth();
 
-module.exports = function auth(request, next) {
+module.exports = function auth(request, next, options) {
+	if (options) {
+		fetchAuth._enableTokenCache = (options.enableTokenCache === true);
+		if (options._resetLocalCache) {
+			fetchAuth._clearLocalCachedTokens();
+		}
+	}
 	return fetchAuth.wrap(request, next);
 };

--- a/test/d2l-fetch-auth-internals/d2l-fetch-auth-internals.js
+++ b/test/d2l-fetch-auth-internals/d2l-fetch-auth-internals.js
@@ -154,7 +154,7 @@ describe('D2LFetchAuth class internals', function() {
 			d2lFetchAuth._getAuthToken()
 				.then(function(token) {
 					expect(token).to.equal(alternativeToken.access_token);
-					d2lFetchAuth._onSessionChanged({ key: 'Session.UserId' });
+					d2lFetchAuth._onStorage({ key: 'Session.UserId' });
 					d2lFetchAuth._getAuthToken()
 						.then(function(token) {
 							expect(token).to.equal(authToken.access_token);


### PR DESCRIPTION
A new attempt at trying to cache the auth token for its lifetime in local storage. This will let us achieve some pretty significant savings for the first API call on a page, which currently almost always falls to the my-courses widget.

Some things to note:
- The caching is currently controlled through an option passed into the plugin, which is `false` by default. This option will be set where the plugin is setup [in BSI](https://github.com/Brightspace/brightspace-integration/blob/master/bsi.html#L9), which in turn will get the value from a LD feature flag.
- Once we're certain this works and are ready to remove the flag, the option will also be removed and caching will always be enabled.
- The cache gets invalidated by a few things:
  1. User logs out (there's a new event that fires to trigger this)
  2. UserId changes via impersonation or logs in as a different user in another tab (or the active tab)
  3. Token expires
- We're using the fact that the `userId` is actually part of the token to determine if the token belongs to the active user