### PR TITLE
Remove demo file

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,8 +1,0 @@
-<!doctype html>
-<head>
-	<script src="https://s.brightspace.com/lib/d2lfetch/1.0.0/d2lfetch.js"></script>
-	<script src="../dist/d2lfetch-auth.js"></script>
-</head>
-<body>
-</body>
-</html>


### PR DESCRIPTION
I went to try to update the demo file to remove the reference to `d2l-fetch` on the CDN, but this demo file doesn't seem to really demo anything... just going to remove for now, and it can be added back if someone has more time to spend on it.