### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "d2l-fetch-auth-framed.js",
     "d2l-fetch-auth.js",
     "index.js"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  }
 }


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564